### PR TITLE
chore: rename package and update patch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nock",
+  "name": "@black-bear-energy/nock",
   "description": "HTTP server mocking and expectations library for Node.js",
   "tags": [
     "Mock",
@@ -7,7 +7,7 @@
     "testing",
     "isolation"
   ],
-  "version": "0.0.0-development",
+  "version": "1.0.0",
   "author": "Pedro Teixeira <pedro.teixeira@gmail.com>",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "testing",
     "isolation"
   ],
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Pedro Teixeira <pedro.teixeira@gmail.com>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Rename the package to allow publishing to npm under the black-bear-energy organization.